### PR TITLE
highlight web text extension

### DIFF
--- a/highlighter-chrome-extension/background.js
+++ b/highlighter-chrome-extension/background.js
@@ -1,0 +1,37 @@
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === "saveHighlight") {
+    saveHighlightToServer(request.text);
+    saveHighlightToStorage(request.text);
+  }
+});
+
+function saveHighlightToServer(text) {
+  // Replace 'YOUR_API_ENDPOINT' with your actual API endpoint
+  console.log("Saving text..", text);
+  // fetch('YOUR_API_ENDPOINT', {
+  //   method: 'POST',
+  //   headers: {
+  //     'Content-Type': 'application/json',
+  //   },
+  //   body: JSON.stringify({ highlight: text }),
+  // })
+  //     .then(response => response.json())
+  //     .then(data => {
+  //       console.log('Highlight saved:', data);
+  //       // You can add logic here to update storage or send a message to the popup
+  //     })
+  //     .catch((error) => {
+  //       console.error('Error:', error);
+  //     });
+}
+
+function saveHighlightToStorage(text) {
+  chrome.storage.local.get(['recentHighlights'], function(result) {
+    let highlights = result.recentHighlights || [];
+    highlights.unshift(text); // Add new highlight to the beginning of the array
+    highlights = highlights.slice(0, 10); // Keep only the 10 most recent highlights
+    chrome.storage.local.set({ recentHighlights: highlights }, function() {
+      console.log('Highlight saved to storage:', text);
+    });
+  });
+}

--- a/highlighter-chrome-extension/content.js
+++ b/highlighter-chrome-extension/content.js
@@ -1,0 +1,14 @@
+document.addEventListener('mouseup', function() {
+  let selectedText = window.getSelection().toString().trim();
+  if (selectedText.length > 0) {
+    highlightText(selectedText);
+    chrome.runtime.sendMessage({action: "saveHighlight", text: selectedText, url: window.location.href});
+  }
+});
+
+function highlightText(text) {
+  let range = window.getSelection().getRangeAt(0);
+  let newNode = document.createElement("span");
+  newNode.setAttribute("style", "background-color: yellow;");
+  range.surroundContents(newNode);
+}

--- a/highlighter-chrome-extension/manifest.json
+++ b/highlighter-chrome-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Text Highlighter",
+  "version": "1.0",
+  "description": "Highlight text and save it to a server",
+  "permissions": ["activeTab", "storage"],
+  "host_permissions": ["<all_urls>"],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ]
+}

--- a/highlighter-chrome-extension/popup.html
+++ b/highlighter-chrome-extension/popup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Text Highlighter</title>
+  <style>
+    body { width: 300px; padding: 10px; }
+    ul { list-style-type: none; padding: 0; }
+    li { margin-bottom: 5px; }
+  </style>
+</head>
+<body>
+<h1>Recent Highlights</h1>
+<ul id="highlights-list"></ul>
+<script src="popup.js"></script>
+</body>
+</html>

--- a/highlighter-chrome-extension/popup.js
+++ b/highlighter-chrome-extension/popup.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function() {
+  // Fetch recent highlights from storage and display them
+  chrome.storage.local.get(['recentHighlights'], function(result) {
+    const highlights = result.recentHighlights || [];
+    const list = document.getElementById('highlights-list');
+    highlights.forEach(function(highlight) {
+      const li = document.createElement('li');
+      li.textContent = highlight;
+      list.appendChild(li);
+    });
+  });
+});


### PR DESCRIPTION
A basic chrome extension that can be used to highlight text on a web-page.
- Right it shows a pop-up list of all last 10 highlights.
- TODO: In background.js hit API call to store these in a remote server so that they can be browsed later.